### PR TITLE
fix: 🐛 `Nano is not available` in first running

### DIFF
--- a/src/utils/ai.ts
+++ b/src/utils/ai.ts
@@ -10,7 +10,7 @@ const checkNanoAvailability = async (api: NanoApi) => {
 
   if ("capabilities" in window.ai[api]) {
     const { available } = await window.ai[api].capabilities();
-    if (available !== "readily") {
+    if (available === "no") {
       throw new Error("Nano is not available");
     }
   }


### PR DESCRIPTION
Refer to official example from: https://docs.google.com/document/d/1VG8HIyz361zGduWgNG7R_R8Xkv0OOJ8b5C9QKeCjU0c/edit?tab=t.0

At once version

```js
// Start by checking if it's possible to create a session based on the availability of the model, and the characteristics of the device.
const {available, defaultTemperature, defaultTopK, maxTopK } = await ai.languageModel.capabilities();

if (available !== "no") {
  const session = await ai.languageModel.create();

  // Prompt the model and wait for the whole result to come back.  
  const result = await session.prompt("Write me a poem");
  console.log(result);
}

```